### PR TITLE
fix: include <gmp.h> before <flint/fmpz.h> to fix cgo build errors on Arch Linux labels: bug, cgo, build

### DIFF
--- a/flint.go
+++ b/flint.go
@@ -10,12 +10,12 @@ package goflint
 #cgo darwin CPPFLAGS: -I/opt/homebrew/include
 #cgo darwin LDFLAGS: -L/opt/homebrew/lib
 #cgo LDFLAGS: -lflint -lgmp
+#include <gmp.h>
 #include <flint/arith.h>
 #include <flint/flint.h>
 #include <flint/fmpz.h>
 #include <flint/fmpq.h>
 #include <flint/nmod_poly.h>
-#include <gmp.h>
 #include <stdlib.h>
 
 // Macros


### PR DESCRIPTION
## Description

The FLINT headers declare `fmpz_get_mpz` and `fmpz_set_mpz` only if `__GMP_H__` is defined, which happens when `<gmp.h>` is included first.  
On some systems like Arch Linux, the order of includes caused cgo to fail with:

![image](https://github.com/user-attachments/assets/33dcdbc0-f4e1-4992-88e1-8498f95b4089)

```
could not determine what C.fmpz_get_mpz refers to
could not determine what C.fmpz_set_mpz refers to
```

This change fixes the issue by including `<gmp.h>` before `<flint/fmpz.h>` in the cgo preamble.

## Changes

- Modified cgo preamble in `flint.go` (or relevant file) to:

```c
#include <gmp.h>
#include <flint/fmpz.h>
```

instead of the reverse.

## Testing

Tested building on Arch Linux and confirmed the cgo build errors are resolved.